### PR TITLE
ws: widen WebSocketTransport supertrait to Send + Sync

### DIFF
--- a/proto-blue/crates/proto-blue-ws/src/transport.rs
+++ b/proto-blue/crates/proto-blue-ws/src/transport.rs
@@ -49,7 +49,7 @@ pub enum WsFrame {
 /// performs a clean shutdown.
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait]
-pub trait WebSocketTransport: Send {
+pub trait WebSocketTransport: Send + Sync {
     async fn recv(&mut self) -> Result<Option<WsFrame>, WsError>;
     async fn send(&mut self, frame: WsFrame) -> Result<(), WsError>;
     async fn close(&mut self) -> Result<(), WsError>;


### PR DESCRIPTION
Discovered while integrating proto-blue 0.2.4 in horizon-firehose. `WebSocketKeepAlive::connect(&mut self)` holds `&self` across `resolve_url(&self).await`, which requires `WebSocketKeepAlive: Sync` to spawn the supervisor on a standard tokio runtime. That propagates down to `dyn WebSocketTransport: Sync`, but the trait supertrait was only `Send` — making it impossible to spawn the keepalive driver on a work-stealing runtime from downstream consumers.

The concrete `TungsteniteTransport` is already `Send + Sync` (wraps tokio-tungstenite which is `Send + Sync`). Widening the supertrait unblocks spawn-based consumers and shouldn't constrain future transport impls that have no reason to not be Sync.

If you have concerns about wasm transports specifically being non-Sync, happy to discuss a feature-flag-guarded alternative. Otherwise this is a one-line compat widening.

Horizon-firehose is using a `[patch]` override against this branch while waiting for merge. Will drop the override and bump the pin once this lands.