### PR TITLE
fix(oauth): PAR client auth for private_key_jwt + correct assertion aud

### DIFF
--- a/proto-blue/crates/proto-blue-oauth/src/client.rs
+++ b/proto-blue/crates/proto-blue-oauth/src/client.rs
@@ -399,12 +399,7 @@ impl OAuthClient {
         let authorization_url =
             if let Some(ref par_endpoint) = server_metadata.pushed_authorization_request_endpoint {
                 let par_response = self
-                    .pushed_authorization_request(
-                        par_endpoint,
-                        &params,
-                        &dpop_key,
-                        server_metadata,
-                    )
+                    .pushed_authorization_request(par_endpoint, &params, &dpop_key, server_metadata)
                     .await?;
 
                 let mut url = Url::parse(&server_metadata.authorization_endpoint)?;

--- a/proto-blue/crates/proto-blue-oauth/src/client.rs
+++ b/proto-blue/crates/proto-blue-oauth/src/client.rs
@@ -167,10 +167,17 @@ impl OAuthClient {
         let Some(key) = keyset.select_for(algs) else {
             return Ok(Vec::new());
         };
+        // `aud` is the AS issuer URL, not the token endpoint. atproto's
+        // reference AS (and the OAuth 2.1 / `oauth-provider` convention)
+        // validates the assertion against `issuer`; using the token
+        // endpoint URL causes the AS to reject with
+        // `unexpected "aud" claim value`. Using the issuer also lets the
+        // same assertion be reused at the PAR endpoint, where the audience
+        // is otherwise ambiguous.
         let assertion = crate::jwt_assertion::build_client_assertion(
             key,
             &self.client_metadata.client_id,
-            &server_metadata.token_endpoint,
+            &server_metadata.issuer,
         )?;
         Ok(vec![
             (
@@ -396,7 +403,7 @@ impl OAuthClient {
                         par_endpoint,
                         &params,
                         &dpop_key,
-                        &server_metadata.token_endpoint,
+                        server_metadata,
                     )
                     .await?;
 
@@ -425,14 +432,27 @@ impl OAuthClient {
     }
 
     /// Send a Pushed Authorization Request (PAR).
+    ///
+    /// PAR endpoints require the same client authentication as the token
+    /// endpoint (RFC 9126 §2). For `private_key_jwt` clients that means
+    /// the `client_assertion` / `client_assertion_type` form fields must
+    /// be included alongside the authorization params — otherwise the AS
+    /// rejects with `invalid_request: client authentication method
+    /// "private_key_jwt" required a "client_assertion"`.
     async fn pushed_authorization_request(
         &self,
         par_endpoint: &str,
         params: &HashMap<&str, String>,
         dpop_key: &DpopKey,
-        _token_endpoint: &str,
+        server_metadata: &OAuthServerMetadata,
     ) -> Result<ParResponse, OAuthError> {
-        let body = encode_form(params.iter().map(|(k, v)| (*k, v.as_str())));
+        let auth_fields = self.client_auth_fields(server_metadata)?;
+        let mut all_fields: Vec<(String, String)> = params
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect();
+        all_fields.extend(auth_fields);
+        let body = encode_form(all_fields.iter().map(|(k, v)| (k.as_str(), v.as_str())));
         let dpop_proof = build_dpop_proof(dpop_key, "POST", par_endpoint, None, None)?;
 
         let resp = self

--- a/proto-blue/crates/proto-blue-oauth/tests/oauth_integration.rs
+++ b/proto-blue/crates/proto-blue-oauth/tests/oauth_integration.rs
@@ -1096,8 +1096,7 @@ async fn authorize_par_omits_client_assertion_when_as_does_not_advertise_alg() {
 
     let par_reply = Reply::json(
         201,
-        br#"{"request_uri":"urn:ietf:params:oauth:request_uri:par-pub","expires_in":90}"#
-            .to_vec(),
+        br#"{"request_uri":"urn:ietf:params:oauth:request_uri:par-pub","expires_in":90}"#.to_vec(),
     );
     let (par_base, cap) = spawn_oneshot(par_reply).await;
     let par_endpoint = format!("{par_base}/par");

--- a/proto-blue/crates/proto-blue-oauth/tests/oauth_integration.rs
+++ b/proto-blue/crates/proto-blue-oauth/tests/oauth_integration.rs
@@ -1014,3 +1014,184 @@ async fn callback_verified_accepts_sub_match_and_records_aud() {
     assert_eq!(ts.sub, "did:plc:good");
     assert_eq!(ts.aud.as_deref(), Some("https://pds.example.com"));
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// PAR + `private_key_jwt` regression coverage
+// ─────────────────────────────────────────────────────────────────────
+
+/// Helper: decode the JWS payload of a compact-JWS `client_assertion`
+/// into a JSON value so tests can assert on its claims.
+fn decode_jws_payload(jws: &str) -> serde_json::Value {
+    use base64::Engine;
+    let mid = jws
+        .split('.')
+        .nth(1)
+        .expect("client_assertion must be a 3-part compact JWS");
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(mid)
+        .expect("payload base64url-decodes");
+    serde_json::from_slice(&bytes).expect("payload is JSON")
+}
+
+/// PAR endpoints require the same client authentication as the token
+/// endpoint (RFC 9126 §2). For `private_key_jwt` clients, the form body
+/// of the PAR request MUST carry `client_assertion_type` and a non-empty
+/// compact-JWS `client_assertion` — otherwise the AS rejects with
+/// `invalid_request` before any user interaction.
+#[tokio::test]
+async fn authorize_par_sends_client_assertion_for_private_key_jwt() {
+    use proto_blue_oauth::{ClientKey, ClientKeyset, DpopAlg};
+
+    let par_reply = Reply::json(
+        201,
+        br#"{"request_uri":"urn:ietf:params:oauth:request_uri:par-pk","expires_in":90}"#.to_vec(),
+    );
+    let (par_base, cap) = spawn_oneshot(par_reply).await;
+    let par_endpoint = format!("{par_base}/par");
+
+    use p256::ecdsa::SigningKey as P256SigningKey;
+    let sk = P256SigningKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+    let key = ClientKey {
+        alg: DpopAlg::Es256,
+        kid: "test-key".into(),
+        d: sk.to_bytes().to_vec(),
+    };
+
+    let client = OAuthClient::new(client_metadata_with_id(
+        "https://app.example.com/metadata.json",
+    ))
+    .with_keyset(ClientKeyset::new().with_key(key));
+
+    let mut meta = server_metadata(
+        "https://as.example.com",
+        "https://as.example.com/authorize",
+        "https://as.example.com/token",
+        Some(&par_endpoint),
+        None,
+    );
+    meta.token_endpoint_auth_signing_alg_values_supported = Some(vec!["ES256".into()]);
+
+    let (_url, _state) = client.authorize(&meta).await.unwrap();
+
+    let req = cap.lock().await.clone().expect("PAR request captured");
+    let form = parse_form(&req.body);
+    assert_eq!(
+        form.get("client_assertion_type").map(String::as_str),
+        Some("urn:ietf:params:oauth:client-assertion-type:jwt-bearer"),
+        "PAR body must carry client_assertion_type for private_key_jwt"
+    );
+    let assertion = form
+        .get("client_assertion")
+        .expect("PAR body must carry a non-empty client_assertion");
+    assert_eq!(assertion.matches('.').count(), 2, "compact JWS has 3 parts");
+}
+
+/// When the AS doesn't advertise any `token_endpoint_auth_signing_alg`
+/// the client falls back to public-client mode — the PAR body must not
+/// contain `client_assertion` even though a keyset is configured.
+/// Counterpart to the equivalent assertion for `refresh_token`.
+#[tokio::test]
+async fn authorize_par_omits_client_assertion_when_as_does_not_advertise_alg() {
+    use proto_blue_oauth::{ClientKey, ClientKeyset, DpopAlg};
+
+    let par_reply = Reply::json(
+        201,
+        br#"{"request_uri":"urn:ietf:params:oauth:request_uri:par-pub","expires_in":90}"#
+            .to_vec(),
+    );
+    let (par_base, cap) = spawn_oneshot(par_reply).await;
+    let par_endpoint = format!("{par_base}/par");
+
+    use p256::ecdsa::SigningKey as P256SigningKey;
+    let sk = P256SigningKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+    let key = ClientKey {
+        alg: DpopAlg::Es256,
+        kid: "test-key".into(),
+        d: sk.to_bytes().to_vec(),
+    };
+
+    let client = OAuthClient::new(client_metadata_with_id(
+        "https://app.example.com/metadata.json",
+    ))
+    .with_keyset(ClientKeyset::new().with_key(key));
+
+    // No `token_endpoint_auth_signing_alg_values_supported`.
+    let meta = server_metadata(
+        "https://as.example.com",
+        "https://as.example.com/authorize",
+        "https://as.example.com/token",
+        Some(&par_endpoint),
+        None,
+    );
+
+    let (_url, _state) = client.authorize(&meta).await.unwrap();
+
+    let req = cap.lock().await.clone().expect("PAR request captured");
+    let form = parse_form(&req.body);
+    assert!(!form.contains_key("client_assertion"));
+    assert!(!form.contains_key("client_assertion_type"));
+}
+
+/// The `aud` claim on a `private_key_jwt` `client_assertion` must equal
+/// the AS issuer URL, not the token endpoint URL. atproto's reference AS
+/// validates against `issuer` and rejects assertions whose `aud` points
+/// at the token endpoint (`unexpected "aud" claim value`).
+#[tokio::test]
+async fn client_assertion_aud_is_issuer_not_token_endpoint() {
+    use proto_blue_oauth::{ClientKey, ClientKeyset, DpopAlg};
+
+    let par_reply = Reply::json(
+        201,
+        br#"{"request_uri":"urn:ietf:params:oauth:request_uri:aud-check","expires_in":90}"#
+            .to_vec(),
+    );
+    let (par_base, cap) = spawn_oneshot(par_reply).await;
+    let par_endpoint = format!("{par_base}/par");
+
+    use p256::ecdsa::SigningKey as P256SigningKey;
+    let sk = P256SigningKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+    let key = ClientKey {
+        alg: DpopAlg::Es256,
+        kid: "test-key".into(),
+        d: sk.to_bytes().to_vec(),
+    };
+
+    let client = OAuthClient::new(client_metadata_with_id(
+        "https://app.example.com/metadata.json",
+    ))
+    .with_keyset(ClientKeyset::new().with_key(key));
+
+    let mut meta = server_metadata(
+        "https://as.example.com",
+        "https://as.example.com/authorize",
+        "https://as.example.com/token",
+        Some(&par_endpoint),
+        None,
+    );
+    meta.token_endpoint_auth_signing_alg_values_supported = Some(vec!["ES256".into()]);
+
+    let (_url, _state) = client.authorize(&meta).await.unwrap();
+
+    let req = cap.lock().await.clone().expect("PAR request captured");
+    let form = parse_form(&req.body);
+    let assertion = form
+        .get("client_assertion")
+        .expect("client_assertion must be present");
+    let payload = decode_jws_payload(assertion);
+
+    assert_eq!(
+        payload.get("aud").and_then(|v| v.as_str()),
+        Some("https://as.example.com"),
+        "aud must be the AS issuer URL, not the token endpoint URL"
+    );
+    assert_eq!(
+        payload.get("iss").and_then(|v| v.as_str()),
+        Some("https://app.example.com/metadata.json"),
+        "iss must be the client_id"
+    );
+    assert_eq!(
+        payload.get("sub").and_then(|v| v.as_str()),
+        Some("https://app.example.com/metadata.json"),
+        "sub must be the client_id"
+    );
+}


### PR DESCRIPTION
## Summary

Two bugs blocked confidential (`private_key_jwt`) clients from completing `OAuthClient::authorize` against atproto's reference AS — see #9 for the full repro.

1. `pushed_authorization_request` built its form body from the authorization params only, never calling `client_auth_fields`. PAR endpoints require the same client auth as the token endpoint (RFC 9126 §2), so the AS rejected with `invalid_request: client authentication method "private_key_jwt" required a "client_assertion"`.
2. `client_auth_fields` set the `client_assertion` `aud` claim to the token endpoint URL. atproto's AS (matching the OAuth 2.1 / `oauth-provider` convention) validates `aud` against the AS issuer and rejected with `unexpected "aud" claim value`. Using the issuer also lets the same assertion be accepted at the PAR endpoint, where the audience would otherwise be ambiguous.

Both fixes are tiny — about 16 lines of behaviour change in `client.rs`.

## Tests

The mock-server integration tests didn't enforce either behaviour, so the path stayed green in CI. Three new tests cover both bugs:

- `authorize_par_sends_client_assertion_for_private_key_jwt` — PAR form body must include `client_assertion_type` + a non-empty compact-JWS `client_assertion`.
- `authorize_par_omits_client_assertion_when_as_does_not_advertise_alg` — public-client fallback still works when the AS doesn't advertise a signing alg.
- `client_assertion_aud_is_issuer_not_token_endpoint` — assertion's `aud` claim equals the AS issuer URL, `iss`/`sub` equal the client_id.

Full test run:

```
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Test plan

- [x] `cargo test -p proto-blue-oauth` — all 24 integration tests + 9 unit tests + 1 session state-machine test pass.
- [x] Verified end-to-end against `bsky.social` from a confidential web client at `https://corvidae.social/oauth/*` — PAR → authorize → callback → revoke round-trip completes successfully with the patch applied.

Fixes #9.